### PR TITLE
refactor(cache): Expire individual items based on point-in-time

### DIFF
--- a/pkg/beacon/expire.go
+++ b/pkg/beacon/expire.go
@@ -1,0 +1,15 @@
+package beacon
+
+import (
+	"time"
+
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+)
+
+func CalculateBlockExpiration(slot phase0.Slot, secondsPerSlot time.Duration, slotsPerEpoch uint64, genesis time.Time, historyDuration time.Duration) time.Time {
+	// Calculate the wall clock for when the block was created
+	createdAt := genesis.Add(time.Duration(uint64(slot)) * secondsPerSlot)
+
+	// Add our configured block history days to the createdAt time
+	return createdAt.Add(historyDuration)
+}

--- a/pkg/beacon/expire_test.go
+++ b/pkg/beacon/expire_test.go
@@ -1,0 +1,61 @@
+package beacon
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+)
+
+var (
+	defaultSecondsPerSlot = time.Second * 12
+	defaultSlotsPerEpoch  = uint64(32)
+)
+
+func TestExpireBlockAdd(t *testing.T) {
+	genesis, _ := time.Parse(time.RFC3339, "2020-01-01T00:00:00Z")
+	daysOfHistory := time.Hour * 24 * 7
+
+	slot := phase0.Slot(1)
+	expiresAt := CalculateBlockExpiration(slot, defaultSecondsPerSlot, defaultSlotsPerEpoch, genesis, daysOfHistory)
+
+	if expiresAt.Before(genesis.Add(time.Hour * 24)) {
+		t.Errorf("Expected block to expire at %v, got %v", genesis.Add(time.Hour*24), expiresAt)
+	}
+
+	if expiresAt.After(genesis.Add(time.Hour * 24 * 8)) {
+		t.Errorf("Expected block to expire at %v, got %v", genesis.Add(time.Hour*24*7), expiresAt)
+	}
+}
+
+func TestExpireMultiple(t *testing.T) {
+	t.Parallel()
+
+	genesis, _ := time.Parse(time.RFC3339, "2020-01-01T00:00:00Z")
+	daysOfHistory := time.Hour * 24 * 7
+
+	tests := []struct {
+		slot   phase0.Slot
+		expect string
+	}{
+		{0, "2020-01-08 00:00:00 +0000 UTC"},
+		{1, "2020-01-08 00:00:12 +0000 UTC"},
+		{2, "2020-01-08 00:00:24 +0000 UTC"},
+		{3, "2020-01-08 00:00:36 +0000 UTC"},
+		{4, "2020-01-08 00:00:48 +0000 UTC"},
+		{5, "2020-01-08 00:01:00 +0000 UTC"},
+		{15000, "2020-01-10 02:00:00 +0000 UTC"},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%v", test.slot), func(t *testing.T) {
+			t.Parallel()
+
+			expiresAt := CalculateBlockExpiration(test.slot, defaultSecondsPerSlot, defaultSlotsPerEpoch, genesis, daysOfHistory)
+			if expiresAt.String() != test.expect {
+				t.Errorf("Expected %v, got %v", test.expect, expiresAt.String())
+			}
+		})
+	}
+}

--- a/pkg/beacon/store/state.go
+++ b/pkg/beacon/store/state.go
@@ -15,14 +15,14 @@ type BeaconState struct {
 	log   logrus.FieldLogger
 }
 
-func NewBeaconState(log logrus.FieldLogger, maxTTL time.Duration, maxItems int, namespace string) *BeaconState {
+func NewBeaconState(log logrus.FieldLogger, maxItems int, namespace string) *BeaconState {
 	c := &BeaconState{
 		log:   log.WithField("component", "beacon/store/beacon_state"),
-		store: cache.NewTTLMap(maxItems, maxTTL, "state", namespace),
+		store: cache.NewTTLMap(maxItems, "state", namespace),
 	}
 
-	c.store.OnItemDeleted(func(key string, value interface{}) {
-		c.log.WithField("state_root", key).Debug("State was deleted from the cache")
+	c.store.OnItemDeleted(func(key string, value interface{}, expiredAt time.Time) {
+		c.log.WithField("state_root", key).WithField("expired_at", expiredAt.String()).Debug("State was deleted from the cache")
 	})
 
 	c.store.EnableMetrics(namespace)
@@ -30,8 +30,8 @@ func NewBeaconState(log logrus.FieldLogger, maxTTL time.Duration, maxItems int, 
 	return c
 }
 
-func (c *BeaconState) Add(stateRoot phase0.Root, state *[]byte) error {
-	c.store.Add(eth.RootAsString(stateRoot), state)
+func (c *BeaconState) Add(stateRoot phase0.Root, state *[]byte, expiresAt time.Time) error {
+	c.store.Add(eth.RootAsString(stateRoot), state, expiresAt)
 	c.log.WithFields(
 		logrus.Fields{
 			"state_root": eth.RootAsString(stateRoot),
@@ -42,7 +42,7 @@ func (c *BeaconState) Add(stateRoot phase0.Root, state *[]byte) error {
 }
 
 func (c *BeaconState) GetByStateRoot(stateRoot phase0.Root) (*[]byte, error) {
-	data, err := c.store.Get(eth.RootAsString(stateRoot))
+	data, _, err := c.store.Get(eth.RootAsString(stateRoot))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This change swaps the `ttl` cache (used to store `state` and `block` items) to expire individual items at a point in time rather than when they were last accessed. If the cache is full, the item closest to expiry will be evicted to make room.

This will let us keep a sliding window of `n days` of blocks for state root/block root lookups, and provides nicer garauntees for data availability for the rest of the app. 