### PR TITLE
feat: Download serving bundle in a queue

### DIFF
--- a/pkg/beacon/metrics.go
+++ b/pkg/beacon/metrics.go
@@ -7,6 +7,7 @@ import (
 
 type Metrics struct {
 	servingEpoch prometheus.Gauge
+	headEpoch    prometheus.Gauge
 }
 
 func NewMetrics(namespace string) *Metrics {
@@ -16,13 +17,23 @@ func NewMetrics(namespace string) *Metrics {
 			Name:      "serving_epoch",
 			Help:      "The current serving epoch",
 		}),
+		headEpoch: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "head_epoch",
+			Help:      "The current head finalized epoch",
+		}),
 	}
 
 	prometheus.MustRegister(m.servingEpoch)
+	prometheus.MustRegister(m.headEpoch)
 
 	return m
 }
 
 func (m *Metrics) ObserveServingEpoch(epoch phase0.Epoch) {
 	m.servingEpoch.Set(float64(uint64(epoch)))
+}
+
+func (m *Metrics) ObserveHeadEpoch(epoch phase0.Epoch) {
+	m.headEpoch.Set(float64(uint64(epoch)))
 }


### PR DESCRIPTION
This fixes a bug that would stop checkpointz from serving the latest finalized checkpoint if the single attempt to download the block/state for the checkpoint failed.

We now check every 1 second if the `head` is different to the epoch we're serving. If they're different, we download the bundle. If the download fails we sleep for 30s and try again next loop.