### PR TITLE
refactor: Rename majority provider to default provider

### DIFF
--- a/pkg/beacon/default.go
+++ b/pkg/beacon/default.go
@@ -45,7 +45,7 @@ var (
 func NewDefaultProvider(namespace string, log logrus.FieldLogger, nodes []node.Config, maxBlockItems, maxStateItems int) FinalityProvider {
 	return &Default{
 		nodeConfigs: nodes,
-		log:         log.WithField("module", "beacon/Default"),
+		log:         log.WithField("module", "beacon/default"),
 		nodes:       NewNodesFromConfig(log, nodes, namespace),
 
 		head:          &v1.Finality{},
@@ -606,7 +606,7 @@ func (d *Default) ListFinalizedSlots(ctx context.Context) ([]phase0.Slot, error)
 
 	latestSlot := phase0.Slot(uint64(finality.Finalized.Epoch) * uint64(d.spec.SlotsPerEpoch))
 
-	for i, val := uint64(latestSlot), uint64(latestSlot)-uint64(d.spec.SlotsPerEpoch)*50; i > val && i >= 0; i -= uint64(d.spec.SlotsPerEpoch) {
+	for i, val := uint64(latestSlot), uint64(latestSlot)-uint64(d.spec.SlotsPerEpoch)*50; i > val; i -= uint64(d.spec.SlotsPerEpoch) {
 		slots = append(slots, phase0.Slot(i))
 	}
 

--- a/pkg/checkpointz/checkpointz.go
+++ b/pkg/checkpointz/checkpointz.go
@@ -30,7 +30,7 @@ func NewServer(log *logrus.Logger, conf *Config) *Server {
 		log.Fatalf("invalid config: %s", err)
 	}
 
-	provider := beacon.NewMajorityProvider(
+	provider := beacon.NewDefaultProvider(
 		namespace,
 		log,
 		conf.BeaconConfig.BeaconUpstreams,


### PR DESCRIPTION
The concept of "majority" has been moved to the `beacon/checkpoints` package, so this struct is really our default implementation of the `checkpointz/beacon/FinalityProvider`.