### PR TITLE
feat: Ban historical slots without a block

### DIFF
--- a/example_config.yaml
+++ b/example_config.yaml
@@ -6,7 +6,7 @@ global:
 checkpointz:
   caches:
     blocks:
-      max_items: 500
+      max_items: 200
     states:
       max_items: 5
   historical_epoch_count: 20

--- a/pkg/beacon/default.go
+++ b/pkg/beacon/default.go
@@ -35,6 +35,8 @@ type Default struct {
 	spec    *state.Spec
 	genesis *v1.Genesis
 
+	historicalSlotFailures map[phase0.Slot]int
+
 	metrics *Metrics
 }
 
@@ -53,6 +55,8 @@ func NewDefaultProvider(namespace string, log logrus.FieldLogger, nodes []node.C
 
 		head:          &v1.Finality{},
 		servingBundle: &v1.Finality{},
+
+		historicalSlotFailures: make(map[phase0.Slot]int),
 
 		broker: emission.NewEmitter(),
 		blocks: store.NewBlock(log, config.Caches.Blocks, namespace),

--- a/pkg/beacon/default.go
+++ b/pkg/beacon/default.go
@@ -435,7 +435,7 @@ func (d *Default) storeBlock(ctx context.Context, block *spec.VersionedSignedBea
 
 	expiresAtSlot := CalculateSlotExpiration(slot, d.config.HistoricalEpochCount*int(d.spec.SlotsPerEpoch))
 	expiresAt := GetSlotTime(expiresAtSlot, d.spec.SecondsPerSlot, d.genesis.GenesisTime).
-		Add((time.Duration(d.spec.SlotsPerEpoch) * d.spec.SecondsPerSlot) * 2) // Store it for an extra 2 epochs to simplify the edge case around expiration.
+		Add(time.Minute * 7) // Store it for an extra 7 minutes to simplify the expiry logic.
 
 	if slot == phase0.Slot(0) {
 		expiresAt = time.Now().Add(999999 * time.Hour)

--- a/pkg/beacon/default.go
+++ b/pkg/beacon/default.go
@@ -435,7 +435,7 @@ func (d *Default) storeBlock(ctx context.Context, block *spec.VersionedSignedBea
 
 	expiresAtSlot := CalculateSlotExpiration(slot, d.config.HistoricalEpochCount*int(d.spec.SlotsPerEpoch))
 	expiresAt := GetSlotTime(expiresAtSlot, d.spec.SecondsPerSlot, d.genesis.GenesisTime).
-		Add(time.Minute * 7) // Store it for an extra 7 minutes to simplify the expiry logic.
+		Add(time.Minute * 15) // Store it for an extra 15 minutes to simplify the expiry logic.
 
 	if slot == phase0.Slot(0) {
 		expiresAt = time.Now().Add(999999 * time.Hour)

--- a/pkg/beacon/download.go
+++ b/pkg/beacon/download.go
@@ -170,6 +170,7 @@ func (d *Default) fetchHistoricalCheckpoints(ctx context.Context, checkpoint *v1
 				WithField("failure_count", failureCount).
 				Error("No longer attempting to download historical block - too many failures")
 		}
+
 		d.historicalSlotFailures[slot] = failureCount
 	}
 

--- a/pkg/beacon/download.go
+++ b/pkg/beacon/download.go
@@ -175,7 +175,7 @@ func (d *Default) fetchHistoricalCheckpoints(ctx context.Context, checkpoint *v1
 	}
 
 	// Cleanup any banned slots that we don't care about anymore to prevent leaking memory.
-	for slot, _ := range d.historicalSlotFailures {
+	for slot := range d.historicalSlotFailures {
 		if _, exists := slotsInScope[slot]; !exists {
 			delete(d.historicalSlotFailures, slot)
 		}

--- a/pkg/beacon/download.go
+++ b/pkg/beacon/download.go
@@ -130,6 +130,8 @@ func (d *Default) fetchHistoricalCheckpoints(ctx context.Context, checkpoint *v1
 
 	sp := d.spec
 
+	slotsInScope := make(map[phase0.Slot]struct{})
+	historicalFailureLimit := 5
 	// Calculate the epoch boundaries we need to fetch
 	// We'll derive the current finalized slot and then work back in intervals of SLOTS_PER_EPOCH.
 	currentSlot := uint64(checkpoint.Finalized.Epoch) * uint64(sp.SlotsPerEpoch)
@@ -139,13 +141,42 @@ func (d *Default) fetchHistoricalCheckpoints(ctx context.Context, checkpoint *v1
 		}
 
 		slot := phase0.Slot(currentSlot - i*uint64(sp.SlotsPerEpoch))
+		slotsInScope[slot] = struct{}{}
+
+		failureCount, exists := d.historicalSlotFailures[slot]
+		if !exists {
+			d.historicalSlotFailures[slot] = 0
+		}
 
 		if _, err := d.blocks.GetBySlot(slot); err == nil {
 			continue
 		}
 
+		if failureCount >= historicalFailureLimit {
+			continue
+		}
+
 		if _, err := d.downloadBlock(ctx, slot, upstream); err != nil {
-			d.log.WithError(err).WithField("slot", eth.SlotAsString(slot)).Error("Failed to download historical block")
+			failureCount++
+
+			d.log.WithError(err).
+				WithField("slot", eth.SlotAsString(slot)).
+				WithField("failure_count", failureCount).
+				Error("Failed to download historical block")
+		}
+
+		if failureCount == historicalFailureLimit {
+			d.log.WithField("slot", eth.SlotAsString(slot)).
+				WithField("failure_count", failureCount).
+				Error("No longer attempting to download historical block - too many failures")
+		}
+		d.historicalSlotFailures[slot] = failureCount
+	}
+
+	// Cleanup any banned slots that we don't care about anymore to prevent leaking memory.
+	for slot, _ := range d.historicalSlotFailures {
+		if _, exists := slotsInScope[slot]; !exists {
+			delete(d.historicalSlotFailures, slot)
 		}
 	}
 


### PR DESCRIPTION
Since we constantly try to backfill our store with historical blocks, the service will constantly try to download the last `n` slots on the epoch boundary, even if they don't have a block.

This change sets a limit on the amount of failures we can have per slot. Unfortunately we can't tell definitively tell if a failure was the result of a network issue, db issue, or if the block doesn't exist in the canonical finalized chain. 