### PR TITLE
feat(beacon): Bump to version 0.3.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.13.0
-	github.com/samcm/beacon v0.2.0
+	github.com/samcm/beacon v0.3.0
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.5.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -262,8 +262,8 @@ github.com/rs/zerolog v1.26.1/go.mod h1:/wSSJWX7lVrsOwlbyTRSOJvqRlc+WjWlfes+CiJ+
 github.com/rs/zerolog v1.27.0 h1:1T7qCieN22GVc8S4Q2yuexzBb1EqjbgjSH9RohbMjKs=
 github.com/rs/zerolog v1.27.0/go.mod h1:7frBqO0oezxmnO7GF86FY++uy8I0Tk/If5ni1G9Qc0U=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/samcm/beacon v0.2.0 h1:RXu0FA50HJshEpALr1xUCXxoU7n63UsY85Uskx5cNnw=
-github.com/samcm/beacon v0.2.0/go.mod h1:PHKxsJH6MOc4f8xUGOkDfGPIe8jqOjMaIN1hST3faWw=
+github.com/samcm/beacon v0.3.0 h1:COYhwhUMfPbxKjQYdjZUidYPcj0FSou0zuOpEJxx/Co=
+github.com/samcm/beacon v0.3.0/go.mod h1:PHKxsJH6MOc4f8xUGOkDfGPIe8jqOjMaIN1hST3faWw=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=


### PR DESCRIPTION
Sets the `beacon.Api` http client timeout to 90s (was 10s).