### PR TITLE
feat: Check for valid historical_epoch_count value

### DIFF
--- a/pkg/beacon/config.go
+++ b/pkg/beacon/config.go
@@ -52,6 +52,10 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("invalid caches config: %s", err)
 	}
 
+	if c.HistoricalEpochCount >= c.Caches.Blocks.MaxItems {
+		return fmt.Errorf("historical_epoch_count (%d) must be less than caches.blocks.max_items (%d)", c.HistoricalEpochCount, c.Caches.Blocks.MaxItems)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Error if the historical_epoch_count is greater than the amount of blocks we can store