### PR TITLE
feat: Add deposit network id -> network name map

### DIFF
--- a/pkg/beacon/default.go
+++ b/pkg/beacon/default.go
@@ -482,7 +482,13 @@ func (d *Default) UpstreamsStatus(ctx context.Context) (map[string]*UpstreamStat
 
 		//nolint:gocritic // invalid
 		if spec, err := node.Beacon.GetSpec(ctx); err == nil {
-			rsp[node.Config.Name].NetworkName = spec.ConfigName
+			network := spec.ConfigName
+			if network == "" {
+				// Fall back to our static map.
+				network = eth.GetNetworkName(spec.DepositChainID)
+			}
+
+			rsp[node.Config.Name].NetworkName = network
 		}
 
 		finality, err := node.Beacon.GetFinality(ctx)

--- a/pkg/beacon/download.go
+++ b/pkg/beacon/download.go
@@ -92,6 +92,10 @@ func (d *Default) checkGenesis(ctx context.Context) error {
 		return err
 	}
 
+	if genesisBlock == nil {
+		return errors.New("invalid genesis block")
+	}
+
 	genesisBlockRoot, err := genesisBlock.Root()
 	if err != nil {
 		return err

--- a/pkg/eth/networks.go
+++ b/pkg/eth/networks.go
@@ -1,0 +1,21 @@
+package eth
+
+func DefaultNetworkIDMap() map[uint64]string {
+	return map[uint64]string{
+		1:        "mainnet",
+		3:        "ropsten",
+		4:        "rinkeby",
+		5:        "goerli",
+		1337802:  "kovan",
+		11155111: "sepolia",
+	}
+}
+
+func GetNetworkName(networkID uint64) string {
+	name, exists := DefaultNetworkIDMap()[networkID]
+	if !exists {
+		return "unknown"
+	}
+
+	return name
+}

--- a/pkg/eth/networks.go
+++ b/pkg/eth/networks.go
@@ -6,7 +6,7 @@ func DefaultNetworkIDMap() map[uint64]string {
 		3:        "ropsten",
 		4:        "rinkeby",
 		5:        "goerli",
-		1337802:  "kovan",
+		1337802:  "kiln",
 		11155111: "sepolia",
 	}
 }


### PR DESCRIPTION
Adds a fallback method of deriving the network name if `spec.CONFIG_NAME` is empty