### PR TITLE
feat: Add genesis block to historical boundary checking

### DIFF
--- a/pkg/beacon/download.go
+++ b/pkg/beacon/download.go
@@ -150,7 +150,7 @@ func (d *Default) fetchHistoricalCheckpoints(ctx context.Context, checkpoint *v1
 		slotsInScope[slot] = struct{}{}
 	}
 
-	for slot, _ := range slotsInScope {
+	for slot := range slotsInScope {
 		failureCount, exists := d.historicalSlotFailures[slot]
 		if !exists {
 			d.historicalSlotFailures[slot] = 0


### PR DESCRIPTION
This fixes a bug where checkpointz would constantly try to download the genesis block over and over again. This is usually fine, but in the case of Goerli (where the first slot had an empty block) using Lodestar, this call fails. Other clients seem to handle this case ok. 

This means that end-clients that depend on the genesis state/block being available, like Prysm, will not be able to use checkpointz if its running against Goerli with a Lodestar upstream. 