### PR TITLE
feat: Bump beacon to 0.4.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,16 +2,15 @@ module github.com/samcm/checkpointz
 
 go 1.17
 
-// replace github.com/samcm/beacon => /Users/samcm/go/src/github.com/samcm/beacon
-
 require (
 	github.com/attestantio/go-eth2-client v0.13.1
 	github.com/chuckpreslar/emission v0.0.0-20170206194824-a7ddd980baf9
+	github.com/creasty/defaults v1.6.0
 	github.com/go-co-op/gocron v1.16.2
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.13.0
-	github.com/samcm/beacon v0.3.0
+	github.com/samcm/beacon v0.4.0
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.5.0
 	gopkg.in/yaml.v2 v2.4.0
@@ -20,7 +19,6 @@ require (
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
-	github.com/creasty/defaults v1.6.0 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/ferranbt/fastssz v0.1.1 // indirect
 	github.com/goccy/go-yaml v1.9.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -264,8 +264,8 @@ github.com/rs/zerolog v1.26.1/go.mod h1:/wSSJWX7lVrsOwlbyTRSOJvqRlc+WjWlfes+CiJ+
 github.com/rs/zerolog v1.27.0 h1:1T7qCieN22GVc8S4Q2yuexzBb1EqjbgjSH9RohbMjKs=
 github.com/rs/zerolog v1.27.0/go.mod h1:7frBqO0oezxmnO7GF86FY++uy8I0Tk/If5ni1G9Qc0U=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/samcm/beacon v0.3.0 h1:COYhwhUMfPbxKjQYdjZUidYPcj0FSou0zuOpEJxx/Co=
-github.com/samcm/beacon v0.3.0/go.mod h1:PHKxsJH6MOc4f8xUGOkDfGPIe8jqOjMaIN1hST3faWw=
+github.com/samcm/beacon v0.4.0 h1:A15TO4yg7gJ1x/7SneRpC7njEdXWQhWXGTmoX3LkQug=
+github.com/samcm/beacon v0.4.0/go.mod h1:PHKxsJH6MOc4f8xUGOkDfGPIe8jqOjMaIN1hST3faWw=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=


### PR DESCRIPTION
This bumps the dep for `samcm/beacon` to `v0.4.0`, which contained a change to fetch finality after the wall clock tells us that an epoch has finished. This should result in checkpointz picking up the new finalized checkpoint quicker.