### PR TITLE
feat: Add additional routes for checkpointz upstream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 bin
 .vscode
 config.yaml
+config2.yaml
 __debug_bin
 dist/
 checkpointz

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.13.0
-	github.com/samcm/beacon v0.5.0
+	github.com/samcm/beacon v0.6.0
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.5.0
 	gopkg.in/yaml.v2 v2.4.0
@@ -19,6 +19,7 @@ require (
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/ferranbt/fastssz v0.1.1 // indirect
 	github.com/goccy/go-yaml v1.9.5 // indirect

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,6 @@ require (
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/ferranbt/fastssz v0.1.1 // indirect
 	github.com/goccy/go-yaml v1.9.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -264,8 +264,8 @@ github.com/rs/zerolog v1.26.1/go.mod h1:/wSSJWX7lVrsOwlbyTRSOJvqRlc+WjWlfes+CiJ+
 github.com/rs/zerolog v1.27.0 h1:1T7qCieN22GVc8S4Q2yuexzBb1EqjbgjSH9RohbMjKs=
 github.com/rs/zerolog v1.27.0/go.mod h1:7frBqO0oezxmnO7GF86FY++uy8I0Tk/If5ni1G9Qc0U=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/samcm/beacon v0.5.0 h1:8R6xOKlSGkTSQuPxtwCCNslEbxpGo7IfPwmaEr5ZOjw=
-github.com/samcm/beacon v0.5.0/go.mod h1:PHKxsJH6MOc4f8xUGOkDfGPIe8jqOjMaIN1hST3faWw=
+github.com/samcm/beacon v0.6.0 h1:4Lsv465/NSFJIKF4YerU8NURUDIeDUabxPvZXCTZfRk=
+github.com/samcm/beacon v0.6.0/go.mod h1:PHKxsJH6MOc4f8xUGOkDfGPIe8jqOjMaIN1hST3faWw=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=

--- a/pkg/api/handler.go
+++ b/pkg/api/handler.go
@@ -359,7 +359,7 @@ func (h *Handler) handleEthV1NodePeerCount(ctx context.Context, r *http.Request,
 		return NewUnsupportedMediaTypeResponse(nil), err
 	}
 
-	peerCount, err := h.eth.PeerCount(ctx)
+	peers, err := h.eth.Peers(ctx)
 	if err != nil {
 		return NewInternalServerErrorResponse(nil), err
 	}
@@ -370,10 +370,10 @@ func (h *Handler) handleEthV1NodePeerCount(ctx context.Context, r *http.Request,
 		Disconnected  string `json:"disconnected"`
 		Disconnecting string `json:"disconnecting"`
 	}{
-		Connected:     fmt.Sprintf("%d", peerCount),
-		Disconnected:  "0",
-		Connecting:    "0",
-		Disconnecting: "0",
+		Connected:     fmt.Sprintf("%d", len(peers.ByState("connected"))),
+		Disconnected:  fmt.Sprintf("%d", len(peers.ByState("disconnected"))),
+		Connecting:    fmt.Sprintf("%d", len(peers.ByState("connecting"))),
+		Disconnecting: fmt.Sprintf("%d", len(peers.ByState("disconnecting"))),
 	}
 
 	var rsp = NewSuccessResponse(ContentTypeResolvers{

--- a/pkg/api/handler.go
+++ b/pkg/api/handler.go
@@ -47,10 +47,21 @@ func NewHandler(log logrus.FieldLogger, beac beacon.FinalityProvider, config *be
 }
 
 func (h *Handler) Register(ctx context.Context, router *httprouter.Router) error {
+	router.GET("/eth/v1/beacon/genesis", h.wrappedHandler(h.handleEthV1BeaconGenesis))
 	router.GET("/eth/v1/beacon/blocks/:block_id/root", h.wrappedHandler(h.handleEthV1BeaconBlocksRoot))
 	router.GET("/eth/v1/beacon/states/:state_id/finality_checkpoints", h.wrappedHandler(h.handleEthV1BeaconStatesHeadFinalityCheckpoints))
 
+	router.GET("/eth/v1/config/spec", h.wrappedHandler(h.handleEthV1ConfigSpec))
+	router.GET("/eth/v1/config/deposit_contract", h.wrappedHandler(h.handleEthV1ConfigDepositContract))
+	router.GET("/eth/v1/config/fork_schedule", h.wrappedHandler(h.handleEthV1ConfigForkSchedule))
+
+	router.GET("/eth/v1/node/syncing", h.wrappedHandler(h.handleEthV1NodeSyncing))
+	router.GET("/eth/v1/node/version", h.wrappedHandler(h.handleEthV1NodeVersion))
+	router.GET("/eth/v1/node/peers", h.wrappedHandler(h.handleEthV1NodePeers))
+	router.GET("/eth/v1/node/peer_count", h.wrappedHandler(h.handleEthV1NodePeerCount))
+
 	router.GET("/eth/v2/beacon/blocks/:block_id", h.wrappedHandler(h.handleEthV2BeaconBlocks))
+
 	router.GET("/eth/v2/debug/beacon/states/:state_id", h.wrappedHandler(h.handleEthV2DebugBeaconStates))
 
 	router.GET("/checkpointz/v1/status", h.wrappedHandler(h.handleCheckpointzStatus))
@@ -123,6 +134,25 @@ func (h *Handler) wrappedHandler(handler func(ctx context.Context, r *http.Reque
 	}
 }
 
+func (h *Handler) handleEthV1BeaconGenesis(ctx context.Context, r *http.Request, p httprouter.Params, contentType ContentType) (*HTTPResponse, error) {
+	if err := ValidateContentType(contentType, []ContentType{ContentTypeJSON}); err != nil {
+		return NewUnsupportedMediaTypeResponse(nil), err
+	}
+
+	genesis, err := h.eth.BeaconGenesis(ctx)
+	if err != nil {
+		return NewInternalServerErrorResponse(nil), err
+	}
+
+	var rsp = NewSuccessResponse(ContentTypeResolvers{
+		ContentTypeJSON: genesis.MarshalJSON,
+	})
+
+	rsp.SetCacheControl("public, s-max-age=30")
+
+	return rsp, nil
+}
+
 func (h *Handler) handleEthV2BeaconBlocks(ctx context.Context, r *http.Request, p httprouter.Params, contentType ContentType) (*HTTPResponse, error) {
 	if err := ValidateContentType(contentType, []ContentType{ContentTypeJSON, ContentTypeSSZ}); err != nil {
 		return NewUnsupportedMediaTypeResponse(nil), err
@@ -159,6 +189,9 @@ func (h *Handler) handleEthV2BeaconBlocks(ctx context.Context, r *http.Request, 
 	default:
 		return NewInternalServerErrorResponse(nil), errors.New("unknown block version")
 	}
+
+	rsp.AddExtraData("version", block.Version.String())
+	rsp.AddExtraData("execution_optimistic", "false")
 
 	switch blockID.Type() {
 	case eth.BlockIDRoot, eth.BlockIDGenesis, eth.BlockIDSlot:
@@ -208,6 +241,169 @@ func (h *Handler) handleEthV2DebugBeaconStates(ctx context.Context, r *http.Requ
 	case eth.StateIDHead:
 		rsp.SetCacheControl("public, s-max-age=30")
 	}
+
+	return rsp, nil
+}
+
+func (h *Handler) handleEthV1ConfigSpec(ctx context.Context, r *http.Request, p httprouter.Params, contentType ContentType) (*HTTPResponse, error) {
+	if err := ValidateContentType(contentType, []ContentType{ContentTypeJSON}); err != nil {
+		return NewUnsupportedMediaTypeResponse(nil), err
+	}
+
+	sp, err := h.eth.ConfigSpec(ctx)
+	if err != nil {
+		return NewInternalServerErrorResponse(nil), err
+	}
+
+	var rsp = NewSuccessResponse(ContentTypeResolvers{
+		ContentTypeJSON: func() ([]byte, error) {
+			return json.Marshal(sp)
+		},
+	})
+
+	rsp.SetCacheControl("public, s-max-age=30")
+
+	return rsp, nil
+}
+
+func (h *Handler) handleEthV1ConfigDepositContract(ctx context.Context, r *http.Request, p httprouter.Params, contentType ContentType) (*HTTPResponse, error) {
+	if err := ValidateContentType(contentType, []ContentType{ContentTypeJSON}); err != nil {
+		return NewUnsupportedMediaTypeResponse(nil), err
+	}
+
+	contract, err := h.eth.DepositContract(ctx)
+	if err != nil {
+		return NewInternalServerErrorResponse(nil), err
+	}
+
+	var rsp = NewSuccessResponse(ContentTypeResolvers{
+		ContentTypeJSON: func() ([]byte, error) {
+			return json.Marshal(contract)
+		},
+	})
+
+	rsp.SetCacheControl("public, s-max-age=30")
+
+	return rsp, nil
+}
+
+func (h *Handler) handleEthV1ConfigForkSchedule(ctx context.Context, r *http.Request, p httprouter.Params, contentType ContentType) (*HTTPResponse, error) {
+	if err := ValidateContentType(contentType, []ContentType{ContentTypeJSON}); err != nil {
+		return NewUnsupportedMediaTypeResponse(nil), err
+	}
+
+	forks, err := h.eth.ForkSchedule(ctx)
+	if err != nil {
+		return NewInternalServerErrorResponse(nil), err
+	}
+
+	var rsp = NewSuccessResponse(ContentTypeResolvers{
+		ContentTypeJSON: func() ([]byte, error) {
+			return json.Marshal(forks)
+		},
+	})
+
+	rsp.SetCacheControl("public, s-max-age=30")
+
+	return rsp, nil
+}
+
+func (h *Handler) handleEthV1NodeSyncing(ctx context.Context, r *http.Request, p httprouter.Params, contentType ContentType) (*HTTPResponse, error) {
+	if err := ValidateContentType(contentType, []ContentType{ContentTypeJSON}); err != nil {
+		return NewUnsupportedMediaTypeResponse(nil), err
+	}
+
+	syncing, err := h.eth.NodeSyncing(ctx)
+	if err != nil {
+		return NewInternalServerErrorResponse(nil), err
+	}
+
+	var rsp = NewSuccessResponse(ContentTypeResolvers{
+		ContentTypeJSON: func() ([]byte, error) {
+			return json.Marshal(syncing)
+		},
+	})
+
+	rsp.SetCacheControl("public, s-max-age=10")
+
+	return rsp, nil
+}
+
+func (h *Handler) handleEthV1NodeVersion(ctx context.Context, r *http.Request, p httprouter.Params, contentType ContentType) (*HTTPResponse, error) {
+	if err := ValidateContentType(contentType, []ContentType{ContentTypeJSON}); err != nil {
+		return NewUnsupportedMediaTypeResponse(nil), err
+	}
+
+	version, err := h.eth.NodeVersion(ctx)
+	if err != nil {
+		return NewInternalServerErrorResponse(nil), err
+	}
+
+	data := struct {
+		Version string `json:"version"`
+	}{Version: version}
+
+	var rsp = NewSuccessResponse(ContentTypeResolvers{
+		ContentTypeJSON: func() ([]byte, error) {
+			return json.Marshal(data)
+		},
+	})
+
+	rsp.SetCacheControl("public, s-max-age=60")
+
+	return rsp, nil
+}
+
+func (h *Handler) handleEthV1NodePeerCount(ctx context.Context, r *http.Request, p httprouter.Params, contentType ContentType) (*HTTPResponse, error) {
+	if err := ValidateContentType(contentType, []ContentType{ContentTypeJSON}); err != nil {
+		return NewUnsupportedMediaTypeResponse(nil), err
+	}
+
+	peerCount, err := h.eth.PeerCount(ctx)
+	if err != nil {
+		return NewInternalServerErrorResponse(nil), err
+	}
+
+	data := struct {
+		Connected     string `json:"connected"`
+		Connecting    string `json:"connecting"`
+		Disconnected  string `json:"disconnected"`
+		Disconnecting string `json:"disconnecting"`
+	}{
+		Connected:     fmt.Sprintf("%d", peerCount),
+		Disconnected:  "0",
+		Connecting:    "0",
+		Disconnecting: "0",
+	}
+
+	var rsp = NewSuccessResponse(ContentTypeResolvers{
+		ContentTypeJSON: func() ([]byte, error) {
+			return json.Marshal(data)
+		},
+	})
+
+	rsp.SetCacheControl("public, s-max-age=60")
+
+	return rsp, nil
+}
+
+func (h *Handler) handleEthV1NodePeers(ctx context.Context, r *http.Request, p httprouter.Params, contentType ContentType) (*HTTPResponse, error) {
+	if err := ValidateContentType(contentType, []ContentType{ContentTypeJSON}); err != nil {
+		return NewUnsupportedMediaTypeResponse(nil), err
+	}
+
+	peers, err := h.eth.Peers(ctx)
+	if err != nil {
+		return NewInternalServerErrorResponse(nil), err
+	}
+
+	var rsp = NewSuccessResponse(ContentTypeResolvers{
+		ContentTypeJSON: func() ([]byte, error) {
+			return json.Marshal(peers)
+		},
+	})
+
+	rsp.SetCacheControl("public, s-max-age=60")
 
 	return rsp, nil
 }

--- a/pkg/api/http.go
+++ b/pkg/api/http.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 )
 
@@ -10,8 +9,7 @@ import (
 func WriteJSONResponse(w http.ResponseWriter, data []byte) error {
 	w.Header().Set("Content-Type", ContentTypeJSON.String())
 
-	//nolint:gocritic // doesnt seem to be a problem
-	if _, err := w.Write([]byte(fmt.Sprintf("{\"data\":%s}", data))); err != nil {
+	if _, err := w.Write(data); err != nil {
 		return err
 	}
 

--- a/pkg/beacon/default.go
+++ b/pkg/beacon/default.go
@@ -265,21 +265,21 @@ func (d *Default) Syncing(ctx context.Context) (*v1.SyncState, error) {
 		SyncDistance: 0,
 	}
 
-	spec, err := d.Spec(ctx)
+	sp, err := d.Spec(ctx)
 	if err != nil {
 		return syncState, err
 	}
 
-	if spec == nil {
+	if sp == nil {
 		return syncState, errors.New("spec unknown")
 	}
 
 	if d.head != nil && d.head.Finalized != nil {
-		syncState.HeadSlot = phase0.Slot(d.head.Finalized.Epoch) * spec.SlotsPerEpoch
+		syncState.HeadSlot = phase0.Slot(d.head.Finalized.Epoch) * sp.SlotsPerEpoch
 	}
 
 	if d.servingBundle != nil && d.servingBundle.Finalized != nil {
-		syncState.SyncDistance = syncState.HeadSlot - phase0.Slot(d.servingBundle.Finalized.Epoch)*spec.SlotsPerEpoch
+		syncState.SyncDistance = syncState.HeadSlot - phase0.Slot(d.servingBundle.Finalized.Epoch)*sp.SlotsPerEpoch
 	}
 
 	return syncState, nil

--- a/pkg/beacon/default.go
+++ b/pkg/beacon/default.go
@@ -285,8 +285,12 @@ func (d *Default) Syncing(ctx context.Context) (*v1.SyncState, error) {
 	return syncState, nil
 }
 
-func (d *Default) Finality(ctx context.Context) (*v1.Finality, error) {
+func (d *Default) Finalized(ctx context.Context) (*v1.Finality, error) {
 	return d.servingBundle, nil
+}
+
+func (d *Default) Head(ctx context.Context) (*v1.Finality, error) {
+	return d.head, nil
 }
 
 func (d *Default) Genesis(ctx context.Context) (*v1.Genesis, error) {
@@ -571,7 +575,7 @@ func (d *Default) ListFinalizedSlots(ctx context.Context) ([]phase0.Slot, error)
 		return slots, errors.New("no beacon chain spec available")
 	}
 
-	finality, err := d.Finality(ctx)
+	finality, err := d.Head(ctx)
 	if err != nil {
 		return slots, err
 	}

--- a/pkg/beacon/finality_provider.go
+++ b/pkg/beacon/finality_provider.go
@@ -6,6 +6,8 @@ import (
 	v1 "github.com/attestantio/go-eth2-client/api/v1"
 	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/samcm/beacon/api/types"
+	"github.com/samcm/beacon/state"
 	"github.com/samcm/checkpointz/pkg/eth"
 )
 
@@ -17,10 +19,18 @@ type FinalityProvider interface {
 	StartAsync(ctx context.Context)
 	// Healthy returns true if the provider is healthy.
 	Healthy(ctx context.Context) (bool, error)
-	// Syncing returns true if the provider is syncing.
-	Syncing(ctx context.Context) (bool, error)
+	// Peers returns the peers the provider is connected to).
+	Peers(ctx context.Context) (types.Peers, error)
+	// PeerCount returns the amount of peers the provider is connected to (the amount of healthy upstreams).
+	PeerCount(ctx context.Context) (uint64, error)
+	// Syncing returns the sync state of the provider.
+	Syncing(ctx context.Context) (*v1.SyncState, error)
 	// Finality returns the finality.
 	Finality(ctx context.Context) (*v1.Finality, error)
+	// Genesis returns the chain genesis.
+	Genesis(ctx context.Context) (*v1.Genesis, error)
+	// Spec returns the chain spec.
+	Spec(ctx context.Context) (*state.Spec, error)
 	// UpstreamsStatus returns the status of all the upstreams.
 	UpstreamsStatus(ctx context.Context) (map[string]*UpstreamStatus, error)
 	// GetBlockBySlot returns the block at the given slot.

--- a/pkg/beacon/finality_provider.go
+++ b/pkg/beacon/finality_provider.go
@@ -25,8 +25,10 @@ type FinalityProvider interface {
 	PeerCount(ctx context.Context) (uint64, error)
 	// Syncing returns the sync state of the provider.
 	Syncing(ctx context.Context) (*v1.SyncState, error)
-	// Finality returns the finality.
-	Finality(ctx context.Context) (*v1.Finality, error)
+	// Head returns the head finality.
+	Head(ctx context.Context) (*v1.Finality, error)
+	// Finalized returns the finalized finality.
+	Finalized(ctx context.Context) (*v1.Finality, error)
 	// Genesis returns the chain genesis.
 	Genesis(ctx context.Context) (*v1.Genesis, error)
 	// Spec returns the chain spec.

--- a/pkg/beacon/nodes.go
+++ b/pkg/beacon/nodes.go
@@ -30,7 +30,7 @@ func NewNodesFromConfig(log logrus.FieldLogger, configs []node.Config, namespace
 
 		opts := *sbeacon.DefaultOptions()
 
-		opts.HealthCheck.Interval.Duration = time.Second * 2
+		opts.HealthCheck.Interval.Duration = time.Second * 5
 		opts.HealthCheck.SuccessfulResponses = 2
 
 		snode := sbeacon.NewNode(log.WithField("upstream", config.Name), sconfig, namespace, opts)

--- a/pkg/eth/string.go
+++ b/pkg/eth/string.go
@@ -13,3 +13,7 @@ func RootAsString(root phase0.Root) string {
 func SlotAsString(slot phase0.Slot) string {
 	return fmt.Sprintf("%d", slot)
 }
+
+func EpochAsString(epoch phase0.Epoch) string {
+	return fmt.Sprintf("%d", epoch)
+}

--- a/pkg/service/checkpointz/checkpointz.go
+++ b/pkg/service/checkpointz/checkpointz.go
@@ -43,7 +43,7 @@ func (h *Handler) V1Status(ctx context.Context, req *StatusRequest) (*StatusResp
 
 	response.Upstreams = upstreams
 
-	finality, err := h.provider.Finality(ctx)
+	finality, err := h.provider.Finalized(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/service/eth/eth.go
+++ b/pkg/service/eth/eth.go
@@ -65,7 +65,7 @@ func (h *Handler) BeaconBlock(ctx context.Context, blockID BlockIdentifier) (*sp
 
 		return h.provider.GetBlockByRoot(ctx, root)
 	case BlockIDFinalized:
-		finality, err := h.provider.Finality(ctx)
+		finality, err := h.provider.Finalized(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -264,7 +264,7 @@ func (h *Handler) BeaconState(ctx context.Context, stateID StateIdentifier) (*[]
 
 		return h.provider.GetBeaconStateByStateRoot(ctx, root)
 	case StateIDFinalized:
-		finality, err := h.provider.Finality(ctx)
+		finality, err := h.provider.Finalized(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -297,7 +297,18 @@ func (h *Handler) FinalityCheckpoints(ctx context.Context, stateID StateIdentifi
 
 	switch stateID.Type() {
 	case StateIDHead:
-		finality, err := h.provider.Finality(ctx)
+		finality, err := h.provider.Head(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		if finality.Finalized == nil {
+			return nil, fmt.Errorf("no finalized state known")
+		}
+
+		return finality, nil
+	case StateIDFinalized:
+		finality, err := h.provider.Finalized(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -371,7 +382,7 @@ func (h *Handler) BlockRoot(ctx context.Context, blockID BlockIdentifier) (phase
 
 		return block.Root()
 	case BlockIDFinalized:
-		finality, err := h.provider.Finality(ctx)
+		finality, err := h.provider.Finalized(ctx)
 		if err != nil {
 			return phase0.Root{}, err
 		}

--- a/pkg/service/eth/types.go
+++ b/pkg/service/eth/types.go
@@ -1,0 +1,6 @@
+package eth
+
+type DepositContract struct {
+	ChainID string `json:"chain_id"`
+	Address string `json:"address"`
+}


### PR DESCRIPTION
This change adds additional APIs that allows Checkpointz to be used as a beacon node upstream from another Checkpointz instance.


This faciliates building a chain of trust that could look something like this in the real world:
```mermaid
graph TD
    A{Sam's Checkpointz} --> B{Local Beacon Node 1}
    A --> D{Community Checkpointz A} --> E{Infura}
    D --> F{Local Beacon Node}
    G{Community Checkpointz A} --> E{Infura}
    A --> G{Community Checkpointz B} --> H
    H{Community Checkpointz C} --> I{Local Beacon Node}
```